### PR TITLE
Adds file gatherer

### DIFF
--- a/cmd/filegather.go
+++ b/cmd/filegather.go
@@ -23,7 +23,7 @@ var filegatherCmd = &cobra.Command{
 
 
 		//we can just unmarshall the file data into the facts ...
-		if gatheredFileName == "" || gatheredFileName == "" {
+		if gatheredFileName == "" {
 			fmt.Errorf("Filename should be passed as argument")
 			os.Exit(1)
 		}

--- a/cmd/filegather.go
+++ b/cmd/filegather.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/bomoko/lagoon-facts/gatherers"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+var gatheredFileName string
+
+// gatherCmd represents the gather command
+var filegatherCmd = &cobra.Command{
+	Use:   "filegather",
+	Short: "Running this command will invoke only invoke the filesystem gatherer",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		var facts []gatherers.GatheredFact
+
+
+		//we can just unmarshall the file data into the facts ...
+		if gatheredFileName == "" || gatheredFileName == "" {
+			fmt.Errorf("Filename should be passed as argument")
+			os.Exit(1)
+		}
+
+		file, _ := ioutil.ReadFile(gatheredFileName)
+		_ = json.Unmarshal([]byte(file), &facts)
+
+		if !dryRun {
+			err := gatherers.Writefacts(projectName, environment, facts)
+			if err != nil {
+				log.Println(err.Error())
+			}
+		}
+
+		if dryRun {
+			if facts != nil {
+				log.Println("---- Dry run ----")
+				log.Printf("Would post the follow facts to '%s:%s'", projectName, environment)
+				s, _ := json.MarshalIndent(facts, "", "\t")
+				log.Println(string(s))
+			}
+		}
+	},
+}
+
+func init() {
+	filegatherCmd.PersistentFlags().StringVarP(&gatheredFileName, "file-name", "f", "", "The file containing the gathered facts")
+	gatherCmd.AddCommand(filegatherCmd)
+}

--- a/cmd/gather.go
+++ b/cmd/gather.go
@@ -18,8 +18,7 @@ var gatherCmd = &cobra.Command{
 	Use:   "gather",
 	Short: "Running this command will invoke the registered gatherers",
 	Long:  `Running all the registered gatherers will inspect the system and write FACT data back to the Lagoon insights system`,
-	Run: func(cmd *cobra.Command, args []string) {
-
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		//get the basic env vars
 		if projectName == "" {
 			projectName = os.Getenv("LAGOON_PROJECT")
@@ -40,7 +39,8 @@ var gatherCmd = &cobra.Command{
 			log.Fatalf("Cannot use both 'static' and 'dynamic' only gatherers - exiting")
 			os.Exit(1)
 		}
-
+	},
+	Run: func(cmd *cobra.Command, args []string) {
 		//set gatherer type to be static by default
 		gathererTypeArg := gatherers.GATHERER_TYPE_STATIC
 		if argDynamic {
@@ -84,9 +84,11 @@ var gatherCmd = &cobra.Command{
 	},
 }
 
+var GatherCommand = gatherCmd
+
 func init() {
 	gatherCmd.PersistentFlags().StringVarP(&projectName, "project-name", "p", "", "The Lagoon project name")
 	gatherCmd.PersistentFlags().StringVarP(&environment, "environment-name", "e", "", "The Lagoon environment name")
-	gatherCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "run gathers and print to screen without running write methods")
+	gatherCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "d", false, "run gathers and print to screen without running write methods")
 	rootCmd.AddCommand(gatherCmd)
 }


### PR DESCRIPTION
This adds a new way of loading up facts - essentially you point it to a .json file and (assuming it can unmarshal the data) - it'll write the data to the target environment.

assuming that the file is `test.json` - you can invoke it as below.

`./builds/lagoon-facts-linux gather filegather --file-name=./test.json`

It's strictly a subcommand of the `gather` parent, but doesn't make use of any of the existing gatherers