### PR TITLE
fix: panic when ssh-agent missing

### DIFF
--- a/utils/token.go
+++ b/utils/token.go
@@ -19,10 +19,15 @@ func sshAgent() ssh.AuthMethod {
 }
 
 func GetToken() (string, error) {
+	agentMethod := sshAgent()
+	if agentMethod == nil {
+		return "", errors.New("couldn't connect to ssh agent")
+	}
+
 	sshConfig := &ssh.ClientConfig{
 		User: "lagoon",
 		Auth: []ssh.AuthMethod{
-			sshAgent(),
+			agentMethod,
 		},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}


### PR DESCRIPTION
If the ssh-agent is not running or can't connect, the app panics because `ssh.AuthMethod` can't have any nil values:

```
LAGOON_PROJECT=foo LAGOON_GIT_BRANCH=branch SSH_AUTH_SOCK=/dev/null go run main.go -v gather
2025/10/01 12:12:40 Drush status gatherer cannot be applied:
2025/10/01 12:12:40 Drush pml gatherer cannot be applied:
2025/10/01 12:12:40 Drush pml gatherer cannot be applied:
2025/10/01 12:12:40 Found PHP version:
2025/10/01 12:12:40 Registering php-version
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x759da1]

goroutine 1 [running]:
golang.org/x/crypto/ssh.(*connection).clientAuthenticate(0xc0000f8c80, 0xc0001bdd40)
        ~/go/pkg/mod/golang.org/x/crypto@v0.31.0/ssh/client_auth.go:99 +0x6e1
golang.org/x/crypto/ssh.(*connection).clientHandshake(0xc0000f8c80, {0x99cbf8, 0x1f}, 0xc0001bdd40)
        ~/go/pkg/mod/golang.org/x/crypto@v0.31.0/ssh/client.go:113 +0x297
golang.org/x/crypto/ssh.NewClientConn({0xa5e498, 0xc000088340}, {0x99cbf8, 0x1f}, 0xc00003f528)
        ~/go/pkg/mod/golang.org/x/crypto@v0.31.0/ssh/client.go:83 +0x125
golang.org/x/crypto/ssh.Dial({0x989d71?, 0x47552e?}, {0x99cbf8, 0x1f}, 0xc00003f528)
        ~/go/pkg/mod/golang.org/x/crypto@v0.31.0/ssh/client.go:181 +0x47
github.com/uselagoon/lagoon-facts-app/utils.GetToken()
        ~/dev/amazee-io/lagoon-facts-app/utils/token.go:35 +0xf4
github.com/uselagoon/lagoon-facts-app/gatherers.getGraphqlClient()
        ~/dev/amazee-io/lagoon-facts-app/gatherers/graphql.go:110 +0x17
github.com/uselagoon/lagoon-facts-app/gatherers.GetProjectId({0xc000012b90, 0xe})
        ~/dev/amazee-io/lagoon-facts-app/gatherers/graphql.go:126 +0x2f
github.com/uselagoon/lagoon-facts-app/gatherers.Writefacts({0xc000012b90, 0xe}, {0xc0000261d2, 0xc}, {0xc0000b4660, 0x1, 0x1})
        ~/dev/amazee-io/lagoon-facts-app/gatherers/graphql.go:17 +0x5a
github.com/uselagoon/lagoon-facts-app/cmd.init.func3(0xc0001a2c00?, {0x989f6d?, 0x4?, 0x989f49?})
        ~/dev/amazee-io/lagoon-facts-app/cmd/gather.go:81 +0x25d
github.com/spf13/cobra.(*Command).execute(0xdca720, {0xc00003a6b0, 0x1, 0x1})
        ~/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0xdcace0)
        ~/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        ~/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/uselagoon/lagoon-facts-app/cmd.Execute()
        ~/dev/amazee-io/lagoon-facts-app/cmd/root.go:44 +0x1a
main.main()
        ~/dev/amazee-io/lagoon-facts-app/main.go:21 +0xf
exit status 2
```

With this fix it throws an error instead:

```
LAGOON_PROJECT=foo LAGOON_GIT_BRANCH=branch SSH_AUTH_SOCK=/dev/null go run main.go -v gather
2025/10/01 12:13:01 Drush status gatherer cannot be applied:
2025/10/01 12:13:01 Drush pml gatherer cannot be applied:
2025/10/01 12:13:01 Drush pml gatherer cannot be applied:
2025/10/01 12:13:01 Found PHP version:
2025/10/01 12:13:01 Registering php-version
2025/10/01 12:13:01 couldn't connect to ssh agent
exit status 1
```